### PR TITLE
Attach api key in request header

### DIFF
--- a/codegen.ts
+++ b/codegen.ts
@@ -2,7 +2,15 @@ import { CodegenConfig } from "@graphql-codegen/cli";
 import Config from "./src/common/config.json";
 
 const config: CodegenConfig = {
-  schema: Config.API.MOHDAPI,
+  schema: [
+    {
+      [Config.API.MOHDAPI]: {
+        headers: {
+          "MOHD-API-Key": process.env.MOHD_API_KEY!,
+        },
+      },
+    },
+  ],
   documents: ["src/**/*.{ts,tsx}"],
   generates: {
     "./src/common/types/generated/": {

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "gen-types": "graphql-codegen",
-    "gen-types -w": "graphql-codegen -w"
+    "gen-types": "dotenv -e .env.local -- graphql-codegen",
+    "gen-types -w": "dotenv -e .env.local -- graphql-codegen -w"
   },
   "dependencies": {
     "@apollo/client": "^3.11.8",
@@ -46,6 +46,7 @@
     "@typescript-eslint/eslint-plugin": "^8.58.0",
     "@typescript-eslint/parser": "^8.58.0",
     "babel-plugin-react-compiler": "1.0.0",
+    "dotenv-cli": "^11.0.0",
     "eslint": "^9",
     "eslint-config-next": "16.2.0",
     "graphql": "^16",

--- a/src/app/api/graphql/route.ts
+++ b/src/app/api/graphql/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import Config from "@/common/config.json";
+
+export async function POST(request: NextRequest) {
+  const body = await request.text();
+
+  const response = await fetch(Config.API.MOHDAPI, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "MOHD-API-Key": process.env.MOHD_API_KEY!,
+    },
+    body,
+  });
+
+  const data = await response.text();
+  return new NextResponse(data, {
+    status: response.status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/src/common/apollo/apollo-wrapper.tsx
+++ b/src/common/apollo/apollo-wrapper.tsx
@@ -8,13 +8,13 @@ import {
   SSRMultipartLink,
   ApolloClient,
 } from "@apollo/experimental-nextjs-app-support";
-import Config from "../config.json";
+
 
 // See https://www.apollographql.com/blog/using-apollo-client-with-next-js-13-releasing-an-official-library-to-support-the-app-router
 
 export function makeClient() {
   const httpLink = new HttpLink({
-    uri: Config.API.MOHDAPI,
+    uri: "/api/graphql",
   });
 
   return new ApolloClient({

--- a/src/common/apollo/client.ts
+++ b/src/common/apollo/client.ts
@@ -11,8 +11,9 @@ export const { getClient, query, PreloadQuery } = registerApolloClient(() => {
     cache: new InMemoryCache(),
     link: new HttpLink({
       uri: Config.API.MOHDAPI,
-      // you can disable result caching here if you want to
-      // (this does not work if you are rendering your page with `export const dynamic = "force-static"`)
+      headers: {
+        "MOHD-API-Key": process.env.MOHD_API_KEY!,
+      },
     }),
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5081,10 +5081,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv@npm:^16.0.0":
+"dotenv-cli@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "dotenv-cli@npm:11.0.0"
+  dependencies:
+    cross-spawn: "npm:^7.0.6"
+    dotenv: "npm:^17.1.0"
+    dotenv-expand: "npm:^12.0.0"
+    minimist: "npm:^1.2.6"
+  bin:
+    dotenv: cli.js
+  checksum: 10c0/c3e6e58a484b3204eeb167a8f78c9cb04c4bae951069e7860eccbbbf96964e3bd808b3632dfe841e5d882b2c5d77c447f20abd06edd4db623ce719d94a7fb44e
+  languageName: node
+  linkType: hard
+
+"dotenv-expand@npm:^12.0.0":
+  version: 12.0.3
+  resolution: "dotenv-expand@npm:12.0.3"
+  dependencies:
+    dotenv: "npm:^16.4.5"
+  checksum: 10c0/0824bdc74fc816a28b0744b7853a23e046602e9616c82121dfdae21ebc13c6e89afeb773e794e97c35d48be2be0a990fbca721ee3869a49c04210a58a3cf296f
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:^16.0.0, dotenv@npm:^16.4.5":
   version: 16.6.1
   resolution: "dotenv@npm:16.6.1"
   checksum: 10c0/15ce56608326ea0d1d9414a5c8ee6dcf0fffc79d2c16422b4ac2268e7e2d76ff5a572d37ffe747c377de12005f14b3cc22361e79fc7f1061cce81f77d2c973dc
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:^17.1.0":
+  version: 17.4.1
+  resolution: "dotenv@npm:17.4.1"
+  checksum: 10c0/eb6ae592ee1e8f6b7f62e0f0c2827c4f27bbe9e00abe9d7910e06456e63dccd42f011de94da9450a63c07ccc52c318f527c1b56ad8e2c81a1a16314b53d4fd99
   languageName: node
   linkType: hard
 
@@ -7398,6 +7428,7 @@ __metadata:
     "@weng-lab/ui-components": "npm:^2.2.4"
     "@weng-lab/visualization": "npm:^1.2.11"
     babel-plugin-react-compiler: "npm:1.0.0"
+    dotenv-cli: "npm:^11.0.0"
     eslint: "npm:^9"
     eslint-config-next: "npm:16.2.0"
     graphql: "npm:^16"


### PR DESCRIPTION
Creates `api/graphql/route.ts` route handler, which all requests go through. This route handler attaches the key in the header using an environmental variable, sends request, and returns response to client.

MOHD-API-Key also attached in `codegen.ts` to ensure auto-generating types isn't blocked, and in `client.ts` for use in server component fetches (no server component fetches used currently).